### PR TITLE
fix-bug -- 使用TreeSelect组件后，重置按钮无法置空该组件值

### DIFF
--- a/src/components/TreeSelect/index.vue
+++ b/src/components/TreeSelect/index.vue
@@ -82,13 +82,15 @@ const defaultExpandedKey = ref([]);
 function initHandle() {
   nextTick(() => {
     const selectedValue = valueId.value;
-    if(selectedValue !== null && typeof (selectedValue) !== "undefined"){
+    if(selectedValue && selectedValue !== null && typeof (selectedValue) !== "undefined"){
       const node = proxy.$refs.selectTree.getNode(selectedValue)
       if (node) {
         valueTitle.value = node.data[props.objMap.label]
         proxy.$refs.selectTree.setCurrentKey(selectedValue) // 设置默认选中
         defaultExpandedKey.value = [selectedValue] // 设置默认展开
       }
+    }else{
+      clearHandle()
     }
   })
 }


### PR DESCRIPTION
使用TreeSelect组件作为某表单域，表单重置按钮无法对其置空。