### PR TITLE
fix: 修复复制的内容动态改变时，指令没更新值的问题

### DIFF
--- a/src/directive/common/copyText.js
+++ b/src/directive/common/copyText.js
@@ -18,6 +18,19 @@ export default {
       el.addEventListener("click", handler);
       el.$destroyCopy = () => el.removeEventListener("click", handler);
     }
+  },
+  beforeUpdate(el, {value, arg}) {
+    // 更新值
+    if (arg === "callback") {
+      el.$copyCallback = value;
+    } else {
+      el.$copyValue = value;
+    }
+  },
+  beforeUnmount(el) {
+    if(el.$destroyCopy) {
+      el.$destroyCopy()
+    }
   }
 }
 


### PR DESCRIPTION
看例子，此种情况，当copyText变更时，是需要同步更新的，同时，组件销毁时也需要移除监听click事件才对
```
// html
<el-button v-copyText="copyText" v-copyText:callback="copySuccess">复制</el-button>

// script
const copyText =computed(() => {
  const text = props.copyList.map(item => `${item.name}: ${item.value ?? ''}`).join('\n');
  return text;
})

function copySuccess() {
  proxy.$modal.msgSuccess("复制成功");
}
```