### PR TITLE
fix: 修复代码生成工具中上级菜单回显问题

### DIFF
--- a/src/views/tool/gen/editTable.vue
+++ b/src/views/tool/gen/editTable.vue
@@ -114,7 +114,7 @@
         </el-table>
       </el-tab-pane>
       <el-tab-pane label="生成信息" name="genInfo">
-        <gen-info-form ref="genInfo" :info="info" :tables="tables" />
+        <gen-info-form ref="genInfo" :info="info" :tables="tables" @update:parentMenuId="handleParentMenuIdUpdate"/>
       </el-tab-pane>
     </el-tabs>
     <el-form label-width="100px">
@@ -175,6 +175,11 @@ function getFormPromise(form) {
     });
   });
 }
+
+function handleParentMenuIdUpdate(newValue) {
+  info.value.parentMenuId = newValue;
+}
+
 function close() {
   const obj = { path: "/tool/gen", query: { t: Date.now(), pageNum: route.query.pageNum } };
   proxy.$tab.closeOpenPage(obj);


### PR DESCRIPTION
问题描述：在使用**代码生成工具**时点击**编辑**，切换到上级菜单，可以看到此时显示的是菜单id而非菜单名称，如下图

<p align="center">
<img src="https://my-picture-bed1-1321100201.cos.ap-beijing.myqcloud.com/mypictures/%E5%9B%9E%E6%98%BE%E6%BC%94%E7%A4%BA%E6%96%B0.gif" alt="回显演示新" width=65% />
<p/>

**我如何解决的？**

1. 在页面获取`menuOptions`后根据menuId对树状选项进行了递归遍历得到menuName，并将menuName设置为树状选择框的初始值。

2. `tree-select`组件内部更新值通知`genInfoForm`组件，再由该组件通知`editTable`组件，实现了`info.parentMenuId`的更新

我测试了**回显**与**正常切换分类**均无bug，测试Gif图如下：

<p align="center">
<img src="https://my-picture-bed1-1321100201.cos.ap-beijing.myqcloud.com/mypictures/%E5%9B%9E%E6%98%BE%E9%97%AE%E9%A2%98%E8%A7%A3%E5%86%B3%E6%BC%94%E7%A4%BA.gif" alt="回显问题解决演示" width=65% />
</p>

