### PR TITLE
feat: 添加jsconfig.json文件

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,18 @@
+{
+    "allowJs": true,
+    "compilerOptions": {
+      "baseUrl": ".",
+      "paths": {
+        "@/*": [
+          "./src/*"
+        ]
+      }
+    },
+    "include": [
+      "src/**/*"
+    ],
+    "exclude": [
+      "node_modules"
+    ]
+  }
+  


### PR DESCRIPTION
添加jsconfig.json文件可以使js项目在 vscode 中可以正确提示路径
显示变量、函数、对象类型（类似ts）

## 更友好的提示
添加之前

![微信图片_20240510102728](https://github.com/yangzongzhuan/RuoYi-Vue3/assets/37854947/eff1b37f-0691-463a-8190-60c49918c643)

添加之后
![微信图片_20240510102735](https://github.com/yangzongzhuan/RuoYi-Vue3/assets/37854947/40f39227-f0cf-4f97-b388-06f459616cd9)
