### PR TITLE
fix: 修复repeatSubmit属性判断逻辑错误，导致请求防重功能不生效

### DIFF
--- a/src/utils/request.js
+++ b/src/utils/request.js
@@ -36,7 +36,7 @@ service.interceptors.request.use(config => {
     config.params = {};
     config.url = url;
   }
-  if (!isRepeatSubmit && (config.method === 'post' || config.method === 'put')) {
+  if (isRepeatSubmit && (config.method === 'post' || config.method === 'put')) {
     const requestObj = {
       url: config.url,
       data: typeof config.data === 'object' ? JSON.stringify(config.data) : config.data,


### PR DESCRIPTION
在Api的request参数中，配置的headers.repeatSubmit设置为false后并未生效，快速连点按钮发起多个相同请求时，会触发多次接口调用，场景如下：
登陆页的登录按钮，注释掉loading状态，即可快速连点触发登录行为
<img width="646" alt="image" src="https://github.com/yangzongzhuan/RuoYi-Vue3/assets/38044652/f9e80e51-a866-4a4f-8e16-c9d6966406ac">
