### PR TITLE
修复升级element-plus出现的警告⚠️提示

### DIFF
--- a/src/components/Crontab/day.vue
+++ b/src/components/Crontab/day.vue
@@ -1,19 +1,19 @@
 <template>
     <el-form>
         <el-form-item>
-            <el-radio v-model='radioValue' :label="1">
+            <el-radio v-model='radioValue' :value="1">
                 日，允许的通配符[, - * ? / L W]
             </el-radio>
         </el-form-item>
 
         <el-form-item>
-            <el-radio v-model='radioValue' :label="2">
+            <el-radio v-model='radioValue' :value="2">
                 不指定
             </el-radio>
         </el-form-item>
 
         <el-form-item>
-            <el-radio v-model='radioValue' :label="3">
+            <el-radio v-model='radioValue' :value="3">
                 周期从
                 <el-input-number v-model='cycle01' :min="1" :max="30" /> -
                 <el-input-number v-model='cycle02' :min="cycle01 + 1" :max="31" /> 日
@@ -21,7 +21,7 @@
         </el-form-item>
 
         <el-form-item>
-            <el-radio v-model='radioValue' :label="4">
+            <el-radio v-model='radioValue' :value="4">
                 从
                 <el-input-number v-model='average01' :min="1" :max="30" /> 号开始，每
                 <el-input-number v-model='average02' :min="1" :max="31 - average01" /> 日执行一次
@@ -29,20 +29,20 @@
         </el-form-item>
 
         <el-form-item>
-            <el-radio v-model='radioValue' :label="5">
+            <el-radio v-model='radioValue' :value="5">
                 每月
                 <el-input-number v-model='workday' :min="1" :max="31" /> 号最近的那个工作日
             </el-radio>
         </el-form-item>
 
         <el-form-item>
-            <el-radio v-model='radioValue' :label="6">
+            <el-radio v-model='radioValue' :value="6">
                 本月最后一天
             </el-radio>
         </el-form-item>
 
         <el-form-item>
-            <el-radio v-model='radioValue' :label="7">
+            <el-radio v-model='radioValue' :value="7">
                 指定
                 <el-select clearable v-model="checkboxList" placeholder="可多选" multiple :multiple-limit="10">
                     <el-option v-for="item in 31" :key="item" :label="item" :value="item" />

--- a/src/components/Crontab/hour.vue
+++ b/src/components/Crontab/hour.vue
@@ -1,13 +1,13 @@
 <template>
     <el-form>
         <el-form-item>
-            <el-radio v-model='radioValue' :label="1">
+            <el-radio v-model='radioValue' :value="1">
                 小时，允许的通配符[, - * /]
             </el-radio>
         </el-form-item>
 
         <el-form-item>
-            <el-radio v-model='radioValue' :label="2">
+            <el-radio v-model='radioValue' :value="2">
                 周期从
                 <el-input-number v-model='cycle01' :min="0" :max="22" /> -
                 <el-input-number v-model='cycle02' :min="cycle01 + 1" :max="23" /> 时
@@ -15,7 +15,7 @@
         </el-form-item>
 
         <el-form-item>
-            <el-radio v-model='radioValue' :label="3">
+            <el-radio v-model='radioValue' :value="3">
                 从
                 <el-input-number v-model='average01' :min="0" :max="22" /> 时开始，每
                 <el-input-number v-model='average02' :min="1" :max="23 - average01" /> 小时执行一次
@@ -23,7 +23,7 @@
         </el-form-item>
 
         <el-form-item>
-            <el-radio v-model='radioValue' :label="4">
+            <el-radio v-model='radioValue' :value="4">
                 指定
                 <el-select clearable v-model="checkboxList" placeholder="可多选" multiple :multiple-limit="10">
                     <el-option v-for="item in 24" :key="item" :label="item - 1" :value="item - 1" />

--- a/src/components/Crontab/min.vue
+++ b/src/components/Crontab/min.vue
@@ -1,13 +1,13 @@
 <template>
     <el-form>
         <el-form-item>
-            <el-radio v-model='radioValue' :label="1">
+            <el-radio v-model='radioValue' :value="1">
                 分钟，允许的通配符[, - * /]
             </el-radio>
         </el-form-item>
 
         <el-form-item>
-            <el-radio v-model='radioValue' :label="2">
+            <el-radio v-model='radioValue' :value="2">
                 周期从
                 <el-input-number v-model='cycle01' :min="0" :max="58" /> -
                 <el-input-number v-model='cycle02' :min="cycle01 + 1" :max="59" /> 分钟
@@ -15,7 +15,7 @@
         </el-form-item>
 
         <el-form-item>
-            <el-radio v-model='radioValue' :label="3">
+            <el-radio v-model='radioValue' :value="3">
                 从
                 <el-input-number v-model='average01' :min="0" :max="58" /> 分钟开始， 每
                 <el-input-number v-model='average02' :min="1" :max="59 - average01" /> 分钟执行一次
@@ -23,7 +23,7 @@
         </el-form-item>
 
         <el-form-item>
-            <el-radio v-model='radioValue' :label="4">
+            <el-radio v-model='radioValue' :value="4">
                 指定
                 <el-select clearable v-model="checkboxList" placeholder="可多选" multiple :multiple-limit="10">
                     <el-option v-for="item in 60" :key="item" :label="item - 1" :value="item - 1" />

--- a/src/components/Crontab/month.vue
+++ b/src/components/Crontab/month.vue
@@ -1,13 +1,13 @@
 <template>
     <el-form>
         <el-form-item>
-            <el-radio v-model='radioValue' :label="1">
+            <el-radio v-model='radioValue' :value="1">
                 月，允许的通配符[, - * /]
             </el-radio>
         </el-form-item>
 
         <el-form-item>
-            <el-radio v-model='radioValue' :label="2">
+            <el-radio v-model='radioValue' :value="2">
                 周期从
                 <el-input-number v-model='cycle01' :min="1" :max="11" /> -
                 <el-input-number v-model='cycle02' :min="cycle01 + 1" :max="12" /> 月
@@ -15,7 +15,7 @@
         </el-form-item>
 
         <el-form-item>
-            <el-radio v-model='radioValue' :label="3">
+            <el-radio v-model='radioValue' :value="3">
                 从
                 <el-input-number v-model='average01' :min="1" :max="11" /> 月开始，每
                 <el-input-number v-model='average02' :min="1" :max="12 - average01" /> 月月执行一次
@@ -23,7 +23,7 @@
         </el-form-item>
 
         <el-form-item>
-            <el-radio v-model='radioValue' :label="4">
+            <el-radio v-model='radioValue' :value="4">
                 指定
                 <el-select clearable v-model="checkboxList" placeholder="可多选" multiple :multiple-limit="8">
                     <el-option v-for="item in monthList" :key="item.key" :label="item.value" :value="item.key" />

--- a/src/components/Crontab/second.vue
+++ b/src/components/Crontab/second.vue
@@ -1,13 +1,13 @@
 <template>
     <el-form>
         <el-form-item>
-            <el-radio v-model='radioValue' :label="1">
+            <el-radio v-model='radioValue' :value="1">
                 秒，允许的通配符[, - * /]
             </el-radio>
         </el-form-item>
 
         <el-form-item>
-            <el-radio v-model='radioValue' :label="2">
+            <el-radio v-model='radioValue' :value="2">
                 周期从
                 <el-input-number v-model='cycle01' :min="0" :max="58" /> -
                 <el-input-number v-model='cycle02' :min="cycle01 + 1" :max="59" /> 秒
@@ -15,7 +15,7 @@
         </el-form-item>
 
         <el-form-item>
-            <el-radio v-model='radioValue' :label="3">
+            <el-radio v-model='radioValue' :value="3">
                 从
                 <el-input-number v-model='average01' :min="0" :max="58" /> 秒开始，每
                 <el-input-number v-model='average02' :min="1" :max="59 - average01" /> 秒执行一次
@@ -23,7 +23,7 @@
         </el-form-item>
 
         <el-form-item>
-            <el-radio v-model='radioValue' :label="4">
+            <el-radio v-model='radioValue' :value="4">
                 指定
                 <el-select clearable v-model="checkboxList" placeholder="可多选" multiple :multiple-limit="10">
                     <el-option v-for="item in 60" :key="item" :label="item - 1" :value="item - 1" />

--- a/src/components/Crontab/week.vue
+++ b/src/components/Crontab/week.vue
@@ -1,19 +1,19 @@
 <template>
     <el-form>
         <el-form-item>
-            <el-radio v-model='radioValue' :label="1">
+            <el-radio v-model='radioValue' :value="1">
                 周，允许的通配符[, - * ? / L #]
             </el-radio>
         </el-form-item>
 
         <el-form-item>
-            <el-radio v-model='radioValue' :label="2">
+            <el-radio v-model='radioValue' :value="2">
                 不指定
             </el-radio>
         </el-form-item>
 
         <el-form-item>
-            <el-radio v-model='radioValue' :label="3">
+            <el-radio v-model='radioValue' :value="3">
                 周期从
                 <el-select clearable v-model="cycle01">
                     <el-option
@@ -38,7 +38,7 @@
         </el-form-item>
 
         <el-form-item>
-            <el-radio v-model='radioValue' :label="4">
+            <el-radio v-model='radioValue' :value="4">
                 第
                 <el-input-number v-model='average01' :min="1" :max="4" /> 周的
                 <el-select clearable v-model="average02">
@@ -48,7 +48,7 @@
         </el-form-item>
 
         <el-form-item>
-            <el-radio v-model='radioValue' :label="5">
+            <el-radio v-model='radioValue' :value="5">
                 本月最后一个
                 <el-select clearable v-model="weekday">
                     <el-option v-for="item in weekList" :key="item.key" :label="item.value" :value="item.key" />
@@ -57,7 +57,7 @@
         </el-form-item>
 
         <el-form-item>
-            <el-radio v-model='radioValue' :label="6">
+            <el-radio v-model='radioValue' :value="6">
                 指定
                 <el-select class="multiselect" clearable v-model="checkboxList" placeholder="可多选" multiple :multiple-limit="6">
                     <el-option v-for="item in weekList" :key="item.key" :label="item.value" :value="item.key" />

--- a/src/components/Crontab/year.vue
+++ b/src/components/Crontab/year.vue
@@ -1,19 +1,19 @@
 <template>
     <el-form>
         <el-form-item>
-            <el-radio :label="1" v-model='radioValue'>
+            <el-radio :value="1" v-model='radioValue'>
                 不填，允许的通配符[, - * /]
             </el-radio>
         </el-form-item>
 
         <el-form-item>
-            <el-radio :label="2" v-model='radioValue'>
+            <el-radio :value="2" v-model='radioValue'>
                 每年
             </el-radio>
         </el-form-item>
 
         <el-form-item>
-            <el-radio :label="3" v-model='radioValue'>
+            <el-radio :value="3" v-model='radioValue'>
                 周期从
                 <el-input-number v-model='cycle01' :min='fullYear' :max="2098"/> -
                 <el-input-number v-model='cycle02' :min="cycle01 ? cycle01 + 1 : fullYear + 1" :max="2099"/>
@@ -21,7 +21,7 @@
         </el-form-item>
 
         <el-form-item>
-            <el-radio :label="4" v-model='radioValue'>
+            <el-radio :value="4" v-model='radioValue'>
                 从
                 <el-input-number v-model='average01' :min='fullYear' :max="2098"/> 年开始，每
                 <el-input-number v-model='average02' :min="1" :max="2099 - average01 || fullYear"/> 年执行一次
@@ -30,7 +30,7 @@
         </el-form-item>
 
         <el-form-item>
-            <el-radio :label="5" v-model='radioValue'>
+            <el-radio :value="5" v-model='radioValue'>
                 指定
                 <el-select clearable v-model="checkboxList" placeholder="可多选" multiple :multiple-limit="8">
                     <el-option v-for="item in 9" :key="item" :value="item - 1 + fullYear" :label="item -1 + fullYear" />

--- a/src/components/DictTag/index.vue
+++ b/src/components/DictTag/index.vue
@@ -10,6 +10,7 @@
         >{{ item.label + " " }}</span>
         <el-tag
           v-else
+          type="primary"
           :disable-transitions="true"
           :key="item.value + ''"
           :index="index"

--- a/src/views/monitor/job/index.vue
+++ b/src/views/monitor/job/index.vue
@@ -196,7 +196,7 @@
                         <el-radio
                            v-for="dict in sys_job_status"
                            :key="dict.value"
-                           :label="dict.value"
+                           :value="dict.value"
                         >{{ dict.label }}</el-radio>
                      </el-radio-group>
                   </el-form-item>
@@ -204,17 +204,17 @@
                <el-col :span="12">
                   <el-form-item label="执行策略" prop="misfirePolicy">
                      <el-radio-group v-model="form.misfirePolicy">
-                        <el-radio-button label="1">立即执行</el-radio-button>
-                        <el-radio-button label="2">执行一次</el-radio-button>
-                        <el-radio-button label="3">放弃执行</el-radio-button>
+                        <el-radio-button value="1">立即执行</el-radio-button>
+                        <el-radio-button value="2">执行一次</el-radio-button>
+                        <el-radio-button value="3">放弃执行</el-radio-button>
                      </el-radio-group>
                   </el-form-item>
                </el-col>
                <el-col :span="12">
                   <el-form-item label="是否并发" prop="concurrent">
                      <el-radio-group v-model="form.concurrent">
-                        <el-radio-button label="0">允许</el-radio-button>
-                        <el-radio-button label="1">禁止</el-radio-button>
+                        <el-radio-button value="0">允许</el-radio-button>
+                        <el-radio-button value="1">禁止</el-radio-button>
                      </el-radio-group>
                   </el-form-item>
                </el-col>

--- a/src/views/system/config/index.vue
+++ b/src/views/system/config/index.vue
@@ -146,7 +146,7 @@
                   <el-radio
                      v-for="dict in sys_yes_no"
                      :key="dict.value"
-                     :label="dict.value"
+                     :value="dict.value"
                   >{{ dict.label }}</el-radio>
                </el-radio-group>
             </el-form-item>

--- a/src/views/system/dept/index.vue
+++ b/src/views/system/dept/index.vue
@@ -123,7 +123,7 @@
                         <el-radio
                            v-for="dict in sys_normal_disable"
                            :key="dict.value"
-                           :label="dict.value"
+                           :value="dict.value"
                         >{{ dict.label }}</el-radio>
                      </el-radio-group>
                   </el-form-item>

--- a/src/views/system/dict/data.vue
+++ b/src/views/system/dict/data.vue
@@ -157,7 +157,7 @@
                   <el-radio
                      v-for="dict in sys_normal_disable"
                      :key="dict.value"
-                     :label="dict.value"
+                     :value="dict.value"
                   >{{ dict.label }}</el-radio>
                </el-radio-group>
             </el-form-item>

--- a/src/views/system/dict/index.vue
+++ b/src/views/system/dict/index.vue
@@ -153,7 +153,7 @@
                   <el-radio
                      v-for="dict in sys_normal_disable"
                      :key="dict.value"
-                     :label="dict.value"
+                     :value="dict.value"
                   >{{ dict.label }}</el-radio>
                </el-radio-group>
             </el-form-item>

--- a/src/views/system/menu/index.vue
+++ b/src/views/system/menu/index.vue
@@ -102,9 +102,9 @@
                <el-col :span="24">
                   <el-form-item label="菜单类型" prop="menuType">
                      <el-radio-group v-model="form.menuType">
-                        <el-radio label="M">目录</el-radio>
-                        <el-radio label="C">菜单</el-radio>
-                        <el-radio label="F">按钮</el-radio>
+                        <el-radio value="M">目录</el-radio>
+                        <el-radio value="C">菜单</el-radio>
+                        <el-radio value="F">按钮</el-radio>
                      </el-radio-group>
                   </el-form-item>
                </el-col>
@@ -152,8 +152,8 @@
                         </span>
                      </template>
                      <el-radio-group v-model="form.isFrame">
-                        <el-radio label="0">是</el-radio>
-                        <el-radio label="1">否</el-radio>
+                        <el-radio value="0">是</el-radio>
+                        <el-radio value="1">否</el-radio>
                      </el-radio-group>
                   </el-form-item>
                </el-col>
@@ -220,8 +220,8 @@
                         </span>
                      </template>
                      <el-radio-group v-model="form.isCache">
-                        <el-radio label="0">缓存</el-radio>
-                        <el-radio label="1">不缓存</el-radio>
+                        <el-radio value="0">缓存</el-radio>
+                        <el-radio value="1">不缓存</el-radio>
                      </el-radio-group>
                   </el-form-item>
                </el-col>
@@ -239,7 +239,7 @@
                         <el-radio
                            v-for="dict in sys_show_hide"
                            :key="dict.value"
-                           :label="dict.value"
+                           :value="dict.value"
                         >{{ dict.label }}</el-radio>
                      </el-radio-group>
                   </el-form-item>
@@ -258,7 +258,7 @@
                         <el-radio
                            v-for="dict in sys_normal_disable"
                            :key="dict.value"
-                           :label="dict.value"
+                           :value="dict.value"
                         >{{ dict.label }}</el-radio>
                      </el-radio-group>
                   </el-form-item>

--- a/src/views/system/notice/index.vue
+++ b/src/views/system/notice/index.vue
@@ -136,7 +136,7 @@
                         <el-radio
                            v-for="dict in sys_notice_status"
                            :key="dict.value"
-                           :label="dict.value"
+                           :value="dict.value"
                         >{{ dict.label }}</el-radio>
                      </el-radio-group>
                   </el-form-item>

--- a/src/views/system/post/index.vue
+++ b/src/views/system/post/index.vue
@@ -126,7 +126,7 @@
                   <el-radio
                      v-for="dict in sys_normal_disable"
                      :key="dict.value"
-                     :label="dict.value"
+                     :value="dict.value"
                   >{{ dict.label }}</el-radio>
                </el-radio-group>
             </el-form-item>

--- a/src/views/system/role/index.vue
+++ b/src/views/system/role/index.vue
@@ -164,7 +164,7 @@
                   <el-radio
                      v-for="dict in sys_normal_disable"
                      :key="dict.value"
-                     :label="dict.value"
+                     :value="dict.value"
                   >{{ dict.label }}</el-radio>
                </el-radio-group>
             </el-form-item>

--- a/src/views/system/user/index.vue
+++ b/src/views/system/user/index.vue
@@ -243,7 +243,7 @@
                         <el-radio
                            v-for="dict in sys_normal_disable"
                            :key="dict.value"
-                           :label="dict.value"
+                           :value="dict.value"
                         >{{ dict.label }}</el-radio>
                      </el-radio-group>
                   </el-form-item>

--- a/src/views/system/user/profile/userInfo.vue
+++ b/src/views/system/user/profile/userInfo.vue
@@ -11,8 +11,8 @@
       </el-form-item>
       <el-form-item label="性别">
          <el-radio-group v-model="form.sex">
-            <el-radio label="0">男</el-radio>
-            <el-radio label="1">女</el-radio>
+            <el-radio value="0">男</el-radio>
+            <el-radio value="1">女</el-radio>
          </el-radio-group>
       </el-form-item>
       <el-form-item>

--- a/src/views/tool/gen/genInfoForm.vue
+++ b/src/views/tool/gen/genInfoForm.vue
@@ -78,8 +78,8 @@
               <el-icon><question-filled /></el-icon>
             </el-tooltip>
           </template>
-          <el-radio v-model="info.genType" label="0">zip压缩包</el-radio>
-          <el-radio v-model="info.genType" label="1">自定义路径</el-radio>
+          <el-radio v-model="info.genType" value="0">zip压缩包</el-radio>
+          <el-radio v-model="info.genType" value="1">自定义路径</el-radio>
         </el-form-item>
       </el-col>
 


### PR DESCRIPTION
1.修复升级element-plus后el-radio使用label过期的问题。
2.修复DictTag组件缺少type的问题