### PR TITLE
更换rightToolBar的显示/隐藏搜索的按钮

### DIFF
--- a/src/components/RightToolbar/index.vue
+++ b/src/components/RightToolbar/index.vue
@@ -2,7 +2,7 @@
   <div class="top-right-btn" :style="style">
     <el-row>
       <el-tooltip class="item" effect="dark" :content="showSearch ? '隐藏搜索' : '显示搜索'" placement="top" v-if="search">
-        <el-button circle icon="Search" @click="toggleSearch()" />
+        <el-button circle :icon="showSearch ? 'Hide' : 'View'" @click="toggleSearch()" />
       </el-tooltip>
       <el-tooltip class="item" effect="dark" content="刷新" placement="top">
         <el-button circle icon="Refresh" @click="refresh()" />


### PR DESCRIPTION
该按钮的作用是显示/隐藏搜索栏。那么按钮的icon对应hide和view就很直观。用search的icon非常奇怪，一眼看过去就以为是搜索按钮