### PR TITLE
fix: 修复Crontab组件年选项卡子项选择无效，averageTotal修改无效。

### DIFF
--- a/src/components/Crontab/year.vue
+++ b/src/components/Crontab/year.vue
@@ -84,7 +84,7 @@ const checkboxString = computed(() => {
     return checkboxList.value.join(',')
 })
 watch(() => props.cron.year, value => changeRadioValue(value))
-watch([radioValue, cycleTotal, averageTotal, checkboxString], () => onRadioChange())
+
 function changeRadioValue(value) {
     if (value === '') {
         radioValue.value = 1
@@ -97,8 +97,8 @@ function changeRadioValue(value) {
         radioValue.value = 3
     } else if (value.indexOf("/") > -1) {
         const indexArr = value.split('/')
-        average01.value = Number(indexArr[1])
-        average02.value = Number(indexArr[0])
+        average01.value = Number(indexArr[0])
+        average02.value = Number(indexArr[1])
         radioValue.value = 4
     } else {
         checkboxList.value = [...new Set(value.split(',').map(item => Number(item)))]
@@ -136,6 +136,8 @@ onMounted(() => {
     cycle02.value = cycle01.value + 1
     average01.value = fullYear.value
     checkCopy.value = [fullYear.value]
+
+    watch([radioValue, cycleTotal, averageTotal, checkboxString], () => onRadioChange())
 })
 </script>
 


### PR DESCRIPTION
1. 修复Crontab组件年选项卡子项选择不生效：
![image](https://github.com/user-attachments/assets/f75badfc-33ba-4556-90fa-04086e79d8e9)
2. 修复Crontab组件年averageTotal修改报错：
![image](https://github.com/user-attachments/assets/f198a66d-2100-4888-8778-e506ae0e4a7f)

