### PR TITLE
修复DictTag组件警告问题

### DIFF
--- a/src/components/DictTag/index.vue
+++ b/src/components/DictTag/index.vue
@@ -13,7 +13,7 @@
           :disable-transitions="true"
           :key="item.value + ''"
           :index="index"
-          :type="item.elTagType === 'primary' ? '' : item.elTagType"
+          :type="item.elTagType === '' ? 'primary' : item.elTagType"
           :class="item.elTagClass"
         >{{ item.label + " " }}</el-tag>
       </template>


### PR DESCRIPTION
el-tag 传入空值会报错，传入的type由 item.elTagType === 'primary' ? '' : item.elTagType"   改为了   item.elTagType === '' ? 'primary' : item.elTagType" 