### PR TITLE
修复DictTag组件中未判断options可能为空/非数组的问题

### DIFF
--- a/src/components/DictTag/index.vue
+++ b/src/components/DictTag/index.vue
@@ -55,7 +55,7 @@ const values = computed(() => {
 const unmatch = computed(() => {
   unmatchArray.value = [];
   // 没有value不显示
-  if (props.value === null || typeof props.value === 'undefined' || props.value === '' || props.options.length === 0) return false
+  if (props.value === null || typeof props.value === 'undefined' || props.value === '' ||  !Array.isArray(props.options) ||  props.options.length === 0) return false
   // 传入值为数组
   let unmatch = false // 添加一个标志来判断是否有未匹配项
   values.value.forEach(item => {


### PR DESCRIPTION
报错截图与错误描述：
![输入图片说明](https://foruda.gitee.com/images/1726801526549003532/35cd731c_14214487.png "屏幕截图")![输入图片说明](https://foruda.gitee.com/images/1726801425245164909/d47045f1_14214487.png "屏幕截图")
# 用户信息表
CREATE TABLE manage_user (
    id BIGINT PRIMARY KEY AUTO_INCREMENT COMMENT '用户ID',
    salt VARCHAR(255) COMMENT '加密盐',
    user_name VARCHAR(36) NOT NULL UNIQUE COMMENT '用户名，12个汉字以内',
    user_password CHAR(32) NOT NULL COMMENT '密码，MD5加密',
    phone VARCHAR(11) NOT NULL COMMENT '手机号',
    user_avatar VARCHAR(255) COMMENT '头像',
    user_backdrop VARCHAR(255) COMMENT '用户背景图片',
    user_certification TINYINT(1) DEFAULT 0 COMMENT '认证情况，0未认证，1已认证',
    user_status TINYINT(1) DEFAULT 0 COMMENT '账户状态，0正常，1锁定',
    created_time TIMESTAMP DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
    updated_time TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '更新时间'
) COMMENT '用户信息表';
![输入图片说明](https://foruda.gitee.com/images/1726800019421193661/845217d8_14214487.png "屏幕截图")

![输入图片说明](https://foruda.gitee.com/images/1726800031306868910/4a573b02_14214487.png "屏幕截图")
![输入图片说明](https://foruda.gitee.com/images/1726800080504884821/372776cd_14214487.png "屏幕截图")
![输入图片说明](https://foruda.gitee.com/images/1726800110871638156/8447261f_14214487.png "屏幕截图")
![报错信息](https://foruda.gitee.com/images/1726801431887258051/a873de82_14214487.png "屏幕截图")![输入图片说明](https://foruda.gitee.com/images/1726800754470529408/eed51c70_14214487.png "屏幕截图")
![输入图片说明](https://foruda.gitee.com/images/1726800799391368782/c0cf6b51_14214487.png "屏幕截图")

修改办法： DictTag组件先判断是不是一个数组即可
下图为修改成功后
![](https://foruda.gitee.com/images/1726801229297310288/c261a756_14214487.png "屏幕截图")
经个人数十次不完全测试Vue2版本没有这个问题

没有看到gitee上由vue3版本的ruoyi官方库，因此已merge request到GitHub

