### PR TITLE
调整IE浏览器判断为`typeof Proxy`，进行vue3兼容性基础判断

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,12 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
   <link rel="icon" href="/favicon.ico">
   <title>若依管理系统</title>
-  <!--[if lt IE 11]><script>window.location.href='/html/ie.html';</script><![endif]-->
+  <!-- 判断是否可以支持Vue3 -->
+  <script>
+    if (typeof Proxy === 'function') {
+      window.location.href='/html/ie.html';
+    }
+  </script>
   <style>
     html,
     body,


### PR DESCRIPTION
原方案条件只能判断小于IE11，并不包含IE11。

IE11无法兼容Proxy等相关Vue3需要的新特性，所以调整判断，以便用户更好的去下载现代化的浏览器。