### PR TITLE
优化 parseTime 函数微秒处理，支持任意长度微秒字符串，避免时间显示异常

### DIFF
--- a/src/utils/ruoyi.js
+++ b/src/utils/ruoyi.js
@@ -16,7 +16,7 @@ export function parseTime(time, pattern) {
     if ((typeof time === 'string') && (/^[0-9]+$/.test(time))) {
       time = parseInt(time)
     } else if (typeof time === 'string') {
-      time = time.replace(new RegExp(/-/gm), '/').replace('T', ' ').replace(new RegExp(/\.[\d]{3}/gm), '')
+      time = time.replace(new RegExp(/-/gm), '/').replace('T', ' ').replace(new RegExp(/\.\d+/gm), '')
     }
     if ((typeof time === 'number') && (time.toString().length === 10)) {
       time = time * 1000


### PR DESCRIPTION
### 问题背景
当前 parseTime 函数在处理带有微秒的时间字符串时，只能正确去除固定三位数的微秒部分（如 .123），
对于任意长度的微秒（如 .123456）无法正确处理，导致前端时间显示异常。

### 修改内容
- 优化正则表达式，将去除微秒部分的正则从 `/\.[\d]{3}/gm` 改为 `/\.\d+/gm`，